### PR TITLE
Early sector files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Mac OSX
+.DS_Store

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,10 @@
+1.1.0dev (2024-09-18)
+=====================
+
+- Added the option to use the initial TESS commissioning PRF files [#9]
+
+1.0.3 (2024-07-30)
+==================
+
+- Initial release
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lkprf"
-version = "1.0.3"
+version = "1.1.0dev"
 description = ""
 authors = ["TESS Science Support Center <tesshelp@bigbang.gsfc.nasa.gov>, Christina Hedges <christina.l.hedges@nasa.gov>"]
 license = "MIT"

--- a/src/lkprf/__init__.py
+++ b/src/lkprf/__init__.py
@@ -1,10 +1,10 @@
 # Standard library
 import os  # noqa
 import logging
+from .version import __version__
 
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
-__version__ = "1.1.0dev"
 logger = logging.getLogger("lkprf")
 
 from .data import *  # noqa

--- a/src/lkprf/__init__.py
+++ b/src/lkprf/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
-__version__ = "1.0.3"
+__version__ = "1.1.0dev"
 logger = logging.getLogger("lkprf")
 
 from .data import *  # noqa

--- a/src/lkprf/data.py
+++ b/src/lkprf/data.py
@@ -174,7 +174,7 @@ def get_kepler_prf_file(module: int, output: int):
     return hdulist
 
 
-def get_tess_prf_file(camera: int, ccd: int, sector: int):
+def get_tess_prf_file(camera: int, ccd: int, sector: int = 4):
     """Get a PRF file for a given camera/ccd/sector"""
     if sector <= 3:
         filename = f"tess-prf-cam{camera}-ccd{ccd}-sec1.fits"

--- a/src/lkprf/data.py
+++ b/src/lkprf/data.py
@@ -170,6 +170,7 @@ def get_kepler_prf_file(module: int, output: int):
         )
         download_kepler_prf_file(module=module, output=output)
     file_path = f"{PACKAGEDIR}/data/{filename}"
+    
     hdulist = fitsio.FITS(file_path)
     return hdulist
 
@@ -186,6 +187,7 @@ def get_tess_prf_file(camera: int, ccd: int, sector: int = 4):
             f"No local files found, building TESS PRF for Camera {camera}, CCD {ccd}."
         )
         build_tess_prf_file(camera=camera, ccd=ccd, sector=sector)
+
     hdulist = fitsio.FITS(file_path)
     return hdulist
 

--- a/src/lkprf/data.py
+++ b/src/lkprf/data.py
@@ -17,6 +17,33 @@ __all__ = [
     "clear_tess_cache",
 ]
 
+_tess_prefixes_S1_3 = {
+    1: {
+        1: "2018243163600",
+        2: "2018243163600",
+        3: "2018243163600",
+        4: "2018243163600",
+    },
+    2: {
+        1: "2018243163600",
+        2: "2018243163600",
+        3: "2018243163600",
+        4: "2018243163601",
+    },
+    3: {
+        1: "2018243163601",
+        2: "2018243163601",
+        3: "2018243163601",
+        4: "2018243163601",
+    },
+    4: {
+        1: "2018243163601",
+        2: "2018243163601",
+        3: "2018243163601",
+        4: "2018243163601",
+    },
+}
+
 
 _tess_prefixes = {
     1: {
@@ -77,7 +104,7 @@ def download_kepler_prf_file(module: int, output: int):
     return
 
 
-def build_tess_prf_file(camera: int, ccd: int):
+def build_tess_prf_file(camera: int, ccd: int, sector: int):
     """Download a set of TESS PRF files for a given camera/ccd"""
 
     def open_file(url: str):
@@ -98,11 +125,19 @@ def build_tess_prf_file(camera: int, ccd: int):
         data[mask] = 0
         return data, hdr
 
-    tess_archive_url = (
-        "https://archive.stsci.edu/missions/tess/models/prf_fitsfiles/start_s0004/"
-    )
-    prefix = _tess_prefixes[camera][ccd]
-    filename = f"tess-prf-{camera}-{ccd}.fits"
+    if sector <= 3:
+        tess_archive_url = (
+            "https://archive.stsci.edu/missions/tess/models/prf_fitsfiles/start_s0001/"
+        )
+        prefix = _tess_prefixes_S1_3[camera][ccd]
+        filename = f"tess-prf-cam{camera}-ccd{ccd}-sec1.fits"
+    else:
+        tess_archive_url = (
+            "https://archive.stsci.edu/missions/tess/models/prf_fitsfiles/start_s0004/"
+        )
+        prefix = _tess_prefixes[camera][ccd]
+        filename = f"tess-prf-cam{camera}-ccd{ccd}-sec4.fits"
+    
     file_path = f"{PACKAGEDIR}/data/{filename}"
     # ensure the file_path exists
     if not os.path.exists(file_path):
@@ -139,15 +174,18 @@ def get_kepler_prf_file(module: int, output: int):
     return hdulist
 
 
-def get_tess_prf_file(camera: int, ccd: int):
-    """Get a PRF file for a given camera/ccd"""
-    filename = f"tess-prf-{camera}-{ccd}.fits"
+def get_tess_prf_file(camera: int, ccd: int, sector: int):
+    """Get a PRF file for a given camera/ccd/sector"""
+    if sector <= 3:
+        filename = f"tess-prf-cam{camera}-ccd{ccd}-sec1.fits"
+    else:
+        filename = f"tess-prf-cam{camera}-ccd{ccd}-sec4.fits"
     file_path = f"{PACKAGEDIR}/data/{filename}"
     if not os.path.isfile(file_path):
         logger.info(
             f"No local files found, building TESS PRF for Camera {camera}, CCD {ccd}."
         )
-        build_tess_prf_file(camera=camera, ccd=ccd)
+        build_tess_prf_file(camera=camera, ccd=ccd, sector=sector)
     hdulist = fitsio.FITS(file_path)
     return hdulist
 

--- a/src/lkprf/prfmodel.py
+++ b/src/lkprf/prfmodel.py
@@ -193,6 +193,7 @@ class PRF(ABC):
         """
 
         hdulist = self._get_prf_data()
+        self.date = hdulist[0].read_header()['DATE']
         PRFdata, crval1p, crval2p, cdelt1p, cdelt2p = [], [], [], [], []
         for hdu in hdulist[1:]:
             PRFdata.append(hdu.read())

--- a/src/lkprf/tessprf.py
+++ b/src/lkprf/tessprf.py
@@ -10,20 +10,22 @@ from .prfmodel import PRF
 
 
 class TESSPRF(PRF):
-    """A TESSPRF class. The TESS PRF measurements are supersampled by a factor of 9."""
+    """A TESSPRF class. The TESS PRF measurements are supersampled by a factor of 9.
+    Two PRF models were produced, one for sectors 1-3 and a second set for sectors 4+ """
 
-    def __init__(self, camera: int, ccd: int):
+    def __init__(self, camera: int, ccd: int, sector: int = 4):
         super().__init__()
         self.camera = camera
         self.ccd = ccd
+        self.sector = sector
         self.mission = "TESS"
         self._prepare_prf()
 
     def __repr__(self):
-        return f"TESSPRF Object [Camera {self.camera}, CCD {self.ccd}]"
+        return f"TESSPRF Object [Camera {self.camera}, CCD {self.ccd}, Sector {self.sector}]"
 
     def _get_prf_data(self):
-        return get_tess_prf_file(camera=self.camera, ccd=self.ccd)
+        return get_tess_prf_file(camera=self.camera, ccd=self.ccd, sector=self.sector)
 
     def update_coordinates(self, targets: List[Tuple], shape: Tuple):
         row, column = self._unpack_targets(targets)

--- a/src/lkprf/version.py
+++ b/src/lkprf/version.py
@@ -1,0 +1,3 @@
+# It is important to store the version number in a separate file
+# so that we can read it without importing the package
+__version__ = "1.1.0dev"

--- a/tests/test_prf.py
+++ b/tests/test_prf.py
@@ -57,3 +57,15 @@ def test_prfs():
         for a in ar:
             assert (a[0] < 0).any()
             assert (a[0] > 0).any()
+
+
+def test_prf_version():
+    prf_sec1_3 = lkprf.TESSPRF(camera=1, ccd=1, sector= 1)
+    prf_sec4_plus = lkprf.TESSPRF(camera=1, ccd=1, sector= 14)
+    # If not specified, should default to sector 4+ measurements
+    prf_sec4_plus2 = lkprf.TESSPRF(camera=1, ccd=1)
+
+    assert prf_sec1_3[1].read_header()['DATE'] == '30-Jan-2019'
+    assert prf_sec4_plus[1].read_header()['DATE'] == '01-May-2019'
+    assert prf_sec4_plus2[1].read_header()['DATE'] == '01-May-2019'
+    

--- a/tests/test_prf.py
+++ b/tests/test_prf.py
@@ -60,12 +60,14 @@ def test_prfs():
 
 
 def test_prf_version():
+    # TESS has a different set of measurements for early (1-3) sectors.
+    # Check to make sure it is reading out different files. 
+
     prf_sec1_3 = lkprf.TESSPRF(camera=1, ccd=1, sector= 1)
     prf_sec4_plus = lkprf.TESSPRF(camera=1, ccd=1, sector= 14)
     # If not specified, should default to sector 4+ measurements
-    prf_sec4_plus2 = lkprf.TESSPRF(camera=1, ccd=1)
-
-    assert prf_sec1_3[1].read_header()['DATE'] == '30-Jan-2019'
-    assert prf_sec4_plus[1].read_header()['DATE'] == '01-May-2019'
-    assert prf_sec4_plus2[1].read_header()['DATE'] == '01-May-2019'
+    prf_sec4_notspecified = lkprf.TESSPRF(camera=1, ccd=1)
     
+    assert prf_sec1_3.date == '30-Jan-2019'
+    assert prf_sec4_plus.date == '01-May-2019'
+    assert prf_sec4_notspecified == '01-May-2019'

--- a/tests/test_prf.py
+++ b/tests/test_prf.py
@@ -70,4 +70,4 @@ def test_prf_version():
     
     assert prf_sec1_3.date == '30-Jan-2019'
     assert prf_sec4_plus.date == '01-May-2019'
-    assert prf_sec4_notspecified == '01-May-2019'
+    assert prf_sec4_notspecified.date == '01-May-2019'


### PR DESCRIPTION
This PR adds the functionality to optionally read in the PRF models produced for TESS sectors 1-3. If no sector is specified, it will default to the PRF models used for sectors 4 and up. 